### PR TITLE
Attempting fix of broken deployment

### DIFF
--- a/src/content/docs/contributors/weekly/24-30 June.md
+++ b/src/content/docs/contributors/weekly/24-30 June.md
@@ -1,5 +1,5 @@
 ---
-week: 24-30 June
+title: week 24-30 June
 ---
 
 Partnerships


### PR DESCRIPTION
"title:" was missing from the 24-30 June.md file 

Without it the Astro schema broke and so it could not deploy new versions as the build threw the following error:

```
Error: 4 [ERROR] [vite] x Build failed in 1.15s
[InvalidContentEntryFrontmatterError] [astro:content-imports] docs → contributors/weekly/24-30 June.md frontmatter does not match collection schema. title: Required
file: /home/runner/work/docs/docs/src/content/docs/contributors/weekly/24-30 June.md?astroContentCollectionEntry=true:0:0
```