### PR TITLE
Bug fix: links in Docs homepage

### DIFF
--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -55,31 +55,31 @@ Whether you're new to *Web3Privacy Now* or looking to deepen your involvement, y
 A summary of what we have already accomplished can be found on the [History](/about-us/history) page.
 
 <CardGrid>
-  <LinkCard title="History" href="/follow-us" />
-  <LinkCard title="Roadmap" href="/roadmap" />
+  <LinkCard title="History" href="/about-us/history" />
+  <LinkCard title="Roadmap" href="/about-us/roadmap" />
 </CardGrid>
 
 ## Become part of the community
 
 <CardGrid>
-  <LinkCard title="Follow us" href="/ecosystem/follow-us" />
-  <LinkCard title="Get involved" href="/get-involved/" />
+  <LinkCard title="Follow us" href="/about-us/follow-us" />
+  <LinkCard title="Get involved" href="/get-involved/index" />
 </CardGrid>
 <CardGrid>
   <LinkCard title="Contributors guide" href="/contributors/" />
-  <LinkCard title="Partnerships" href="/get-involved/partnerships" />
+  <LinkCard title="Partnerships" href="/get-involved/partnership" />
 </CardGrid>
 <CardGrid>
-  <LinkCard title="Donate" href="/donate" />
-  <LinkCard title="Code of Conduct" href="/code-of-conduct" />
+  <LinkCard title="Donate" href="/get-involved/donate" />
+  <LinkCard title="Code of Conduct" href="/get-involved/code-of-conduct" />
 </CardGrid>
 
 ## For contributors
 
-We use various [Communication tools](/ecosystem/communication). For our work we use different [Git repositories](/contributors/git), and for organizational purposes our effort is divided into several [Workgroups](/contributors/workgroups).
+We use various [Communication tools](/governance/communication). For our work we use different [Git repositories](/contributors/git), and for organizational purposes our effort is divided into several [Workgroups](/contributors/workgroups).
 
 <CardGrid>
-  <LinkCard title="Communication tools" href="/ecosystem/communication" />
+  <LinkCard title="Communication tools" href="/governance/communication" />
   <LinkCard title="Git repositories" href="/contributors/git" />
 </CardGrid>
 <CardGrid>
@@ -102,4 +102,4 @@ The initiative is managed by a [Core Team](/governance/core-team) of four people
 
 ## We are very open 💛
 
-All our activities are public and fully [open-source](/contributors/git). Feel free to [contribute](/contributors/)!
+All our activities are public and fully [open-source](/contributors/git). Feel free to [contribute](/contributors/index) or [donate directly](get-involved/donate) to support us!


### PR DESCRIPTION
Fixing reported bug

The file links in 'cards' of the homepage of Docs were no longer pointing to correct location in Docs after the reorganisation of folders. Fixed for homepage - Scanning to see if other links are broken