### PR TITLE
[Broken Links Fix] - internal and external links within the docs

### DIFF
--- a/src/content/docs/about-us/history.md
+++ b/src/content/docs/about-us/history.md
@@ -68,7 +68,7 @@ Historical track record of *Web3Privacy Now*.
 * **Article**: _From scoring model to interfaces: Web3privacy now_: [Mirror](https://mirror.xyz/0x0f1F3DAf416B74DB3DE55Eb4D7513a80F4841073/f3EXL1pAuI6gusHf_soq9KopU8ABC1EcV002FFlYKoM)
 * **Judging**: _ETHRome privacy & governance hackathon_
 * **Article**: _Making web3-privacy assessment research: public feedback_: [Mirror](https://mirror.xyz/0x0f1F3DAf416B74DB3DE55Eb4D7513a80F4841073/E9QPx9iKgPXPqEsAN-YklipSRJy9VTBMOLwwEcqqVpU)
-* **Development**: _Explorer platform prototyping_: [Hackathon project](https://taikai.network/ethrome/hackathons/ethrome-23/projects/clng508ts00lswu01030hpfuq/idea)
+* **Development**: _Explorer platform prototyping_: [Hackathon project](https://taikai.network/ethrome/hackathons/ethrome-23/projects/clng508ts00lswu01030hpfuq)
 * **Research**: _Data Manifest for Explorer platform_: [GitHub](https://github.com/web3privacy/data/tree/main#readme)
 * **Design**: _Explorer platform visual prototype_: [Figma](https://www.figma.com/file/fwUaS88ao4Ijlv3gIDYrQD/Web3Privacy?type=design&node-id=668%3A26840&mode=design&t=xWVqvb2facrhUFGj-1), [Try prototype](https://www.figma.com/proto/fwUaS88ao4Ijlv3gIDYrQD/Web3Privacy?page-id=558%3A22&type=design&node-id=668-26840&viewport=-5271%2C542%2C0.19&t=7yVsL5QlUqoAGn2T-1&scaling=scale-down-width&starting-point-node-id=668%3A26840&mode=design)
 * **Development**: _Explorer platform live demo_: [Vercel](https://web3privacy-app.vercel.app), [GitHub](https://github.com/web3privacy/web3privacy-app)

--- a/src/content/docs/about-us/history.md
+++ b/src/content/docs/about-us/history.md
@@ -36,7 +36,7 @@ Historical track record of *Web3Privacy Now*.
 - [Web3 Privacy DB (+500 projects)](https://web3privacy.info/)
 - [Report: Web3 Privacy Market Overview, Jan 2023](https://github.com/web3privacy/web3privacy/blob/main/Market%20overview/Web3privacy%20landscape%20(jan%202023).jpg)
 - [Web3 Privacy Landscape](https://github.com/web3privacy/web3privacy/blob/main/Market%20overview/Web3privacy%20landscape%20(jan%202023).jpg)
-- [Pagency Framework](https://github.com/web3privacy/docs/blob/main/src/content/docs/research/pagency.md)
+- [Pagency Framework](https://docs.web3privacy.info/research/pagency/)
 - [Privacy use-cases](https://github.com/web3privacy/web3privacy/blob/main/Use-cases.md)
 - [Web3 Privacy Jobs ](https://docs.google.com/spreadsheets/d/1dN6bIWyOh01Dl-y1iZh-1TASZxKUefD098BUALcnUb8/edit#gid=0)
 - [ZK Privacy Landscape](https://github.com/web3privacy/web3privacy/tree/main/ZKprivacylandscape)

--- a/src/content/docs/about-us/history.md
+++ b/src/content/docs/about-us/history.md
@@ -112,7 +112,7 @@ Historical track record of *Web3Privacy Now*.
 * **Talk**: _UkraineDAO on privacy x Mykola_: [X Spaces](https://twitter.com/cryptodrftng/status/1616807220628291585)
 * **Infographic**: _Web3privacy landscape_: [GitHub](https://github.com/web3privacy/web3privacy/blob/main/Market%20overview/Web3privacy%20landscape%20(jan%202023).jpg)
 * **Infographic**: _ZK x Privacy landscape_: [GitHub](https://github.com/web3privacy/web3privacy/blob/main/Market%20overview/ZK-private%20landscape.jpg)
-* **Research**: _ZK x Privacy DB_: [GitHub](https://github.com/web3privacy/web3privacy/tree/main/ZKprivacylandscape)
+* **Research**: _ZK x Privacy DB_: [GitHub](https://github.com/web3privacy/web3privacy/tree/main/Market%20overview/ZK%20privacy%20landscape)
 * **Research**: _300 projects in our Privacy services in Web3 database_: [GitHub](https://github.com/web3privacy/web3privacy)
 * **Research**: _Privacy assessment platform concept_: [GitHub](https://github.com/web3privacy/web3privacy/tree/main/Web3privacynowplatform)
 * **Research**: _Privacy assessment market survey_: [GitHub](https://github.com/web3privacy/web3privacy/tree/main/Web3privacynowplatform/scoringmodel/Survey), [Spreadsheet](https://docs.google.com/spreadsheets/d/1JWpAsGL10UTsVeuIVbouzUxRjaSPUAamxcbFljXuUWE/edit#gid=0)

--- a/src/content/docs/about-us/roadmap.md
+++ b/src/content/docs/about-us/roadmap.md
@@ -18,7 +18,7 @@ _via_
 
 | | 2024 Roadmap |
 | --- | --- |
-| ⚙️ Core Initiative | • [Partnership](/partnership/) & [Core team](/governance/core-team)) |
+| ⚙️ Core Initiative | • [Partnership](/get-involved/partnership/) & [Core team](/governance/core-team)) |
 | 🔬 [Research](/research/) | Upcoming reports:<br/> • [Privacy Guides for the general public](https://github.com/web3privacy/grants/blob/main/README.md#-privacy-guides)<br/>• [Scoring Model v2.0](https://github.com/web3privacy/grants/blob/main/README.md#-privacy-beat)<br/>• [Hackathon Curation Pack](https://github.com/web3privacy/grants/blob/main/README.md#-hackathon-curation-pack)<br/>• [Ethereum Privacy Ecosystem](https://docs.web3privacy.info/research/ethereum-privacy-ecosystem) |
 | 📅 [Events](/events/) | 2024 Season:<br/> • 17 events in 14 countries<br/> • 1 hackathon, 2 summits, 14 meetups |
 | 👁️ [Privacy Explorer](/projects/privacy-explorer) | [v2.0](/projects/privacy-explorer#milestones) upgrade |

--- a/src/content/docs/contributors/deploy-event-website.md
+++ b/src/content/docs/contributors/deploy-event-website.md
@@ -26,7 +26,7 @@ The cost for us to deploy a new website is basically zero (aside from contributo
 - [ ] In the main window, under the 'Source' section, ensure 'Deploy from Branch' option is selected in the dropdown menu
 - [ ] Underneith it in the 'Branch' section, use the dropdown and select 'main' (next to it the '/root' option will autoselect itself)
 - [ ] In this section 'Branch', click on the 'Save' button, the webpage will reload
-- [ ] After a few  minutes Github Pages will deploy your code online, go to the Deployments section of your project (Example: [https://github.com/web3privacy/c24bkk/deployments/github-pages](https://github.com/web3privacy/c24bkk/deployments/github-pages))
+- [ ] After a few  minutes Github Pages will deploy your code online, go to the Deployments section of your project (Example: [https://github.com/web3privacy/c24bkk/deployments](https://github.com/web3privacy/c24bkk/deployments))
 - [ ] Here you can see the current deployments, their URL, a button to visit the site, and also where the option to Unpublish it is available
 
 ### Part 2: Porkbun

--- a/src/content/docs/contributors/git.md
+++ b/src/content/docs/contributors/git.md
@@ -10,12 +10,12 @@ All our projects are open-source and distributed across many Git repositories. P
 
 | Repository | Description |
 | --- | --- |
-| [@web3privacy/web3privacy](https://github.com/web3privacy/web3privacy) | The original monorepo with research |
-| [@web3privacy/data](https://github.com/web3privacy/data) | Data repository (Team, Projects, Events..) |
-| [@web3privacy/core](https://github.com/web3privacy/core) | [Core Team](/core-team) Project Management |
-| [@web3privacy/docs](https://github.com/web3privacy/docs) | Source code of this documentation |
-| [@web3privacy/web](https://github.com/web3privacy/web) | Source-code of our website ([web3privacy.info](https://web3privacy.info)) |
-| [@web3privacy/brand](https://github.com/web3privacy/brand) | Brand assets (logos and other visual) |
+| [web3privacy/web3privacy](https://github.com/web3privacy/web3privacy) | The original monorepo with research |
+| [web3privacy/data](https://github.com/web3privacy/data) | Data repository (Team, Projects, Events..) |
+| [web3privacy/core](https://github.com/web3privacy/core) | [Core Team](/governance/core-team) Project Management |
+| [web3privacy/docs](https://github.com/web3privacy/docs) | Source code of this documentation |
+| [web3privacy/web](https://github.com/web3privacy/web) | Source-code of our website ([web3privacy.info](https://web3privacy.info)) |
+| [web3privacy/brand](https://github.com/web3privacy/brand) | Brand assets (logos and other visual) |
 
 ### Projects-related
 

--- a/src/content/docs/contributors/index.md
+++ b/src/content/docs/contributors/index.md
@@ -34,7 +34,7 @@ For any question or doubt don't hesitate to dm us on [Twitter](https://x.com/web
 Here is a list of our ongoing activities. Feel free to **contribute on GitHub** or **DM Shepards** expressing your willingness to commit for receiving instructions.
 
 ### ⎆[Jobs](https://github.com/web3privacy/jobs-app)
-_Shepherds: [Adam](https://x.com/vorcigernix), [Mykola](@nicksvyaznoy)_
+_Shepherds: [Adam](https://x.com/vorcigernix), [Mykola](https://x.com/nicksvyaznoy)_
 
 - improve project
 - test and find bugs

--- a/src/content/docs/contributors/index.md
+++ b/src/content/docs/contributors/index.md
@@ -43,14 +43,14 @@ _Shepherds: [Adam](https://x.com/vorcigernix), [Mykola](https://x.com/nicksvyazn
 
 
 ### ⎆[Explorer](https://github.com/web3privacy/explorer-app)
-_Shepherds: [MF](https://x.com/0x_m_f), [Mykola](@nicksvyaznoy)_
+_Shepherds: [MF](https://x.com/0x_m_f), [Mykola](https://x.com/nicksvyaznoy)_
 
 - improve project
 - collect data
 - fix issues
  
 ### ⎆[Academy ](https://github.com/web3privacy/cypherpunkacademy/blob/main/README.md)
-_Shepherds: [PG](https://x.com/PG_CDG), [Mykola](@nicksvyaznoy)_
+_Shepherds: [PG](https://x.com/PG_CDG), [Mykola](https://x.com/nicksvyaznoy)_
 
 - improve project
 - add suggestions via doc (Cryptpad)
@@ -69,20 +69,20 @@ _Shepherds: _[Jensei](https://x.com/jensei_),[PG](https://x.com/PG_CDG)_
 - collaborate with jensei 
 
 ### ⎆[Privacy Local cases](https://github.com/web3privacy/privacycases) 
-_Shepherds: _[Mykola](@nicksvyaznoy),[PG](https://x.com/PG_CDG)_
+_Shepherds: _[Mykola](https://x.com/nicksvyaznoy),[PG](https://x.com/PG_CDG)_
 
 - improve project
 - collect use-cases in your country
 
 ### ⎆[ Idea Generator](https://github.com/hackyguru/web3privacy-ideas)
-_Shepherds: _[Mykola](@nicksvyaznoy), [Guru](https://x.com/hackyguru)_
+_Shepherds: _[Mykola](https://x.com/nicksvyaznoy), [Guru](https://x.com/hackyguru)_
 
 - improve project
 - fix bugs
 - transform plain text use-cases into json
 
 ### ⎆[ Web3Privacy Database](https://github.com/web3privacy/web3privacy)
-_Shepherds: _[Mykola](@nicksvyaznoy),[PG](https://x.com/PG_CDG)_
+_Shepherds: _[Mykola](https://x.com/nicksvyaznoy),[PG](https://x.com/PG_CDG)_
 
 Here is a step-by-step guide on how to maintain our privacy DB updated via PR at GitHub:
 

--- a/src/content/docs/contributors/workgroups.md
+++ b/src/content/docs/contributors/workgroups.md
@@ -10,10 +10,10 @@ Here you will find an overview of all the workgroups together with the people in
 
 | Name | Lead | Members | Links |
 | --- | --- | --- | --- |
-| [**Core Team**](/core-team) | Mykola, PG, Coinmandeer, niclaz | [PM](https://github.com/orgs/web3privacy/projects/8), 🔒 [GitHub](https://github.com/web3privacy/core-internal), 🔒 Matrix |
+| [**Core Team**](/about-us/core-team) | Mykola, PG, Coinmandeer, niclaz | [PM](https://github.com/orgs/web3privacy/projects/8), 🔒 [GitHub](https://github.com/web3privacy/core), 🔒 Matrix |
 | **Marketing & Outreach** | Mykola | PG |
 | **Partnerships** | PG | Mykola | 🔒 [PM](https://github.com/orgs/web3privacy/projects/10), 🔒 Matrix |
-| **IT Operation** | niclaz | ||
+| **IT Operations** | niclaz | ||
 | **Design department** | Coinmandeer | ||
 
 🔒 - private tool (non-public)

--- a/src/content/docs/events/congress.md
+++ b/src/content/docs/events/congress.md
@@ -15,9 +15,9 @@ The Congress is held once a year.
 
 * a vote on the long-term direction of the initiative
 * approval of the financial plan for the following year
-* election of [Core Team](governance/core-team) members (3 year election period)
+* election of [Core Team](/governance/core-team) members (3 year election period)
 * election of members of the executive body of the *Association Committee* (5 year election period)
 
 ## Who makes the decisions
 
-* our [Members](/partnership) with a voting rights
+* our [Members](/get-involved/partnership) with a voting rights

--- a/src/content/docs/events/index.mdx
+++ b/src/content/docs/events/index.mdx
@@ -31,7 +31,7 @@ The source files with basic data about our events can be found in our `data` [Gi
 * [`@web3privacy/data`](https://github.com/web3privacy/data) (`src/events` directory)
 
 *Feel free to add an event by making a PR to the web3privacy/data/src/events* 
-Please do read this docs page in full, respect the naming convention noted here, and follow the [how to add an event to website guide](/get-involved/add-event-to-website) `work-in-progress`
+Please do read this docs page in full, respect the naming convention noted here, and follow the [how to add an event to website guide](/contributors/add-event-to-website) `work-in-progress`
 
 | Guide | Link | Status |
 | Adding a new event to website | pending | `work-in-progress` |

--- a/src/content/docs/events/index.mdx
+++ b/src/content/docs/events/index.mdx
@@ -181,7 +181,7 @@ Whether a particular event is free or we charge admission will depend on the con
 
 We will apply admission fees where we expect a lot of interest and, on the contrary, events in less busy periods should be free of charge, which will serve as an incentive for visitors.
 
-All our [members](/membership/#personal-membership) have a **free admission** to event, even if an entry fee is applied.
+All our [members](/get-involved/personal-benefits) have a **free admission** to event, even if an entry fee is applied.
 
 ### Pre-registration
 

--- a/src/content/docs/events/types.md
+++ b/src/content/docs/events/types.md
@@ -22,7 +22,7 @@ We divide events into the following types according to their length and goal:
 | --- | --- | --- | --- |
 | [Privacy Corner](https://github.com/web3privacy/privacy-corner) (`c`) | - | $3-10k | pop-up space inside of major hackathons |
 | [Meta-hackathon](#meta-hackathon) (`q`) | *variable* | $15-30k | a multi-day event focused on W3PN activities |
-| [Congress](/congress) (`x`) | - | ? | W3PN governance gathering |
+| [Congress](/events/congress) (`x`) | - | ? | W3PN governance gathering |
 
 ## Details of types
 

--- a/src/content/docs/get-involved/index.md
+++ b/src/content/docs/get-involved/index.md
@@ -9,7 +9,7 @@ sidebar:
 
 ## GIT CONTRIBUTIONS
 This is the kind of support we value most: open-source, grassroots initiatives driven by individual passion and care. 
-To learn how to become a contributor, discover which projects you can assist with, or start a new one, visit the [Contributors Guide](https://docs.web3privacy.info/contributors/)
+To learn how to become a contributor, discover which projects you can assist with, or start a new one, visit the [Contributors Guide](/contributors/index)
 
 
 ## SPONSORSHIP
@@ -36,6 +36,6 @@ Our mission is to delve into digital privacy from a broad spectrum of viewpoints
 ## DONATE
 Our diverse array of research, projects development, events and tools production is all offered freely, fueled by people and organizations who care about digital privacy.
 
-⎆ [Donate now](https://docs.web3privacy.info/donate/), support our independence, and help us to advocate for freedom!
+⎆ [Donate now](/get-involved/donate/), support our independence, and help us to advocate for freedom!
 
 

--- a/src/content/docs/get-involved/partnership.md
+++ b/src/content/docs/get-involved/partnership.md
@@ -1,3 +1,6 @@
+---
+title: Partnership
+---
 
 # MEMBERS
 

--- a/src/content/docs/get-involved/personal-benefits.md
+++ b/src/content/docs/get-involved/personal-benefits.md
@@ -12,6 +12,6 @@ title: Membership x individuals
 - Discount in our store (25%)
 - 100 EUR/year
 
-⎆ [Become a Member](https://docs.web3privacy.info/donate/)
+⎆ [Become a Member](/get-involved/donate/)
 
 _After making your donation, kindly send us the tx hash, your T-shirt size, and let us know if you would like your membership to be public or kept private._

--- a/src/content/docs/governance/core-team.md
+++ b/src/content/docs/governance/core-team.md
@@ -29,10 +29,10 @@ Core Team members are elected by decision of the [Congress](/events/congress) fo
 
 | Repository | Description |
 | --- | --- |
-| [@web3privacy/core](https://github.com/web3privacy/core) | Core team PM | 
-| [@web3privacy/core-internal](https://github.com/web3privacy/core-internal) 🔒 | Core team internals (private) | 
-| [@web3privacy/dns-zones](https://github.com/web3privacy/dns-zones) 🔒 | Our DNS zones (private) | 
-| [@web3privacy/sysop-info](https://github.com/web3privacy/sysop-info) 🔒 | Basic sysop info (private) | 
+| [web3privacy/core](https://github.com/web3privacy/core) | Core team PM | 
+| [web3privacy/core-internal](https://github.com/web3privacy/core-internal) 🔒 | Core team internals (private) | 
+| [web3privacy/dns-zones](https://github.com/web3privacy/dns-zones) 🔒 | Our DNS zones (private) | 
+| [web3privacy/sysop-info](https://github.com/web3privacy/sysop-info) 🔒 | Basic sysop info (private) | 
 
 ## Matrix channels
 

--- a/src/content/docs/governance/governance.mdx
+++ b/src/content/docs/governance/governance.mdx
@@ -14,7 +14,7 @@ Below, we share our insights, highlighting our missteps to inspire others.
 
 ![Governance Structure](../assets/gov-stru.png)
 
-Anyone who assists in the completion of our projects and activities is considered a contributor. Frequent contributors have the chance to become [Core Contributors](https://docs.web3privacy.info/core-contributors/) and receive rewards for their contributions to open source.
+Anyone who assists in the completion of our projects and activities is considered a contributor. Frequent contributors have the chance to become [Core Contributors](/governance/core-contributors/) and receive rewards for their contributions to open source.
 
 ### Proof of Care - *become a Core Contributor*
 
@@ -72,7 +72,7 @@ Sorted by competencies - from least to most.
 | Guest / Visitor | none | 🔒 private |
 | [Members](/get-involved/partnership) | none | 🔒 private |
 | [Members](/get-involved/partnership) with voting rights | voting on the [congress](/congress) | 🔒 private |
-| [Workgroup](/get-involved/workgroups) member (*contributor*) | decision-making within the working group | 🔒 private |
+| [Workgroup](/contributors/workgroups) member (*contributor*) | decision-making within the working group | 🔒 private |
 | [Contributors Guild](/contributors/index) member* | receives financial compensation | 🥷 pseudonym (name, link) |
 | Association Committee member* | operate with finances and curate [Contributors Guild](/contributors/index) | 👁️ public |
 | [Core Team](/governance/core-team) member* | decides on the most important issues, controls Association | 🥷 pseudonym (name, link) |

--- a/src/content/docs/governance/governance.mdx
+++ b/src/content/docs/governance/governance.mdx
@@ -40,28 +40,29 @@ We attempted to establish different departments, a legal entity, and infrastruct
 <LinkCard
   title="Congress"
   description="Top organ, votes on most important issues, elects Core Team/Association executives"
-  href="/congress"
+  href="/events/congress"
 />
 <LinkCard
   title="Core Team"
   description="Main decision-making and executive body"
-  href="/core-team"
+  href="/governance/core-team"
 />
 <LinkCard
-  title="Association"
-  description="Legal entity, executes Core Team requirements, accepts donations, pay expenses"
-  href="/association"
+  title="Core Contributors"
+  description="Group of members receiving incentives"
+  href="/governance/core-contributors"
+/>
+<LinkCard
+  title="Become a Contributor"
+  description="How to contribute to the Web3Privacy Now project"
+  href="/get-involved/index"
 />
 <LinkCard
   title="Treasury"
   description="Fund management"
-  href="/treasury"
+  href="/governance/treasury"
 />
-<LinkCard
-  title="Contributors Guild"
-  description="Group of members receiving incentives"
-  href="/guild"
-/>
+
 
 ### Personal roles within initiative
 
@@ -71,7 +72,7 @@ Sorted by competencies - from least to most.
 | --- | --- | --- |
 | Guest / Visitor | none | 🔒 private |
 | [Members](/get-involved/partnership) | none | 🔒 private |
-| [Members](/get-involved/partnership) with voting rights | voting on the [congress](/congress) | 🔒 private |
+| [Members](/get-involved/partnership) with voting rights | voting on the [congress](/events/congress) | 🔒 private |
 | [Workgroup](/contributors/workgroups) member (*contributor*) | decision-making within the working group | 🔒 private |
 | [Contributors Guild](/contributors/index) member* | receives financial compensation | 🥷 pseudonym (name, link) |
 | Association Committee member* | operate with finances and curate [Contributors Guild](/contributors/index) | 👁️ public |

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -90,7 +90,7 @@ We use various [Communication tools](/governance/communication). For our work we
 
 The initiative is managed by a [Core Team](/governance/core-team) of four people who take care of operations. We are also in the process of creating Association as legal entity for our activities.
 
-<LinkCard title="Governance structure" href="/governance/" />
+<LinkCard title="Governance structure" href="/governance/governance/" />
 <CardGrid>
     <LinkCard title="Congress" href="/events/congress" />
     <LinkCard title="Core Team" href="/governance/core-team" />

--- a/src/content/docs/research/usecase-db.md
+++ b/src/content/docs/research/usecase-db.md
@@ -18,5 +18,3 @@ Ideas & references for privacy builders
 - Expand use-cases database
 
 ### Phase 1: initial DB aggregaton 23'
-
-[DB](https://github.com/Msiusko/web3privacy/blob/main/Use-cases.md)

--- a/src/content/docs/resources/design.md
+++ b/src/content/docs/resources/design.md
@@ -2,4 +2,4 @@
 title: Design
 ---
 
-If you need help with the visual side of your project, then you can use our pre-made templates (TODO) or contact our [Design workgroup](/workgroups#internal).
+If you need help with the visual side of your project, then you can use our pre-made templates (TODO) or contact our [Design workgroup](/contributors/workgroups).

--- a/src/content/docs/resources/developers.mdx
+++ b/src/content/docs/resources/developers.mdx
@@ -6,7 +6,7 @@ import { LinkCard } from '@astrojs/starlight/components';
 
 If you're looking for developers who can help you build your privacy-related project, then the Web3Privacy Now community is the perfect place where to start.
 
-Most of the developers can be found in the [Devs channel](https://matrix.to/#/%23w3p-devs:gwei.cz) on our [Matrix](/communication/#matrix-chat) chat.
+Most of the developers can be found in the [Devs channel](https://matrix.to/#/%23w3p-devs:gwei.cz) on our [Matrix](/governance/communication/) chat.
 
 <LinkCard title="💬 Devs channel on Matrix" href="https://matrix.to/#/%23w3p-devs:gwei.cz" />
 

--- a/src/content/docs/resources/funding.md
+++ b/src/content/docs/resources/funding.md
@@ -12,11 +12,11 @@ We are developing a transparent grant system that will serve as the main way to 
 * operating costs
 * marketing and promotional expenses
 
-The subject of the funding request cannot be the direct payment of contributors - for these purposes it is necessary to become a member of the [Contributors Guild](/guild).
+The subject of the funding request cannot be the direct payment of contributors - for these purposes it is necessary to become an active [Contributors to the project](/contributors/index).
 
 ## Funding Requests
 
-*Funding Request Proposals* (FRPs) is a transparent application process to receive money from our [Treasury](/treasury). Most of our income is redistributed through these applications.
+*Funding Request Proposals* (FRPs) is a transparent application process to receive money from our [Treasury](/governance/treasury). Most of our income is redistributed through these applications.
 
 Each application will be assessed by members of the [Core Team](/core-team), according to whose decision it will be accepted or rejected.
 

--- a/src/content/docs/resources/it-infrastructure.md
+++ b/src/content/docs/resources/it-infrastructure.md
@@ -4,7 +4,7 @@ title: IT Infrastructure
 
 Our initiative operates various shared IT services that are available to all our contributors and projects.
 
-If you are interested in using any of our shared IT infrastructure, please contact the [IT Operation Workgroup](/workgroups#internal) members.
+If you are interested in using any of our shared IT infrastructure, please contact the [IT Operation Workgroup](/contributors/workgroups) members.
 
 ## General overview
 

--- a/src/content/docs/resources/legal-assistance.md
+++ b/src/content/docs/resources/legal-assistance.md
@@ -2,7 +2,7 @@
 title: Legal assistance
 ---
 
-Legal assistance is provided through our [Association](/association). This is particularly useful for physical activities such as [Events](/events) where formal official communication or contracts is required.
+Legal assistance is provided through our members and partners. This is particularly useful for physical activities such as [Events](/events/index) where formal official communication or contracts is required.
 
 ## What we can do
 - taking over the responsibility for contracts with suppliers

--- a/src/content/docs/resources/training-education.mdx
+++ b/src/content/docs/resources/training-education.mdx
@@ -10,6 +10,6 @@ Education is very important to us, which is why we run various educational progr
 
 An annual multi-day gathering of people around Web3Privacy Now, where we educate each other and move our project forward.
 
-[Meta-hackathon](/events/types/#meta-hackathon) is an event organized by our [Events](/events) department.
+[Meta-hackathon](/events/types/#meta-hackathon) is an event organized by our [Events Workgroup](/contributors/workgroups).
 
 <LinkCard title="List of W3PN meta-hackathons" href="https://web3privacy.info/events/meta-hackathon/" />

--- a/src/content/docs/resources/training-education.mdx
+++ b/src/content/docs/resources/training-education.mdx
@@ -4,7 +4,7 @@ title: Training and Education
 
 import { LinkCard } from '@astrojs/starlight/components';
 
-Education is very important to us, which is why we run various educational programs and workshops, both for our contributors and the wider community as part of our [Partners](/partners) program. 
+Education is very important to us, which is why we run various educational programs and workshops, both for our contributors and the wider community as part of our [Partners](/get-involved/partnership) program. 
 
 ## W3PN Meta-hackathons
 


### PR DESCRIPTION
After the reorganization of the items within docs last month in PR #19 there were some broken links within content 

I ran two broken link checker services on the deployed docs instance and followed up with edits to fix these broken links:
https://www.deadlinkchecker.com
https://www.brokenlinkcheck.com

Most were internal, but not all - there were also a handful of false positives in the tests

Additional commit: fixing the error in governance.md that broke the deployment process